### PR TITLE
Foreground SdlService, update gradle file, and update the manifest file to include metadata additions

### DIFF
--- a/hello_sdl_android/app/build.gradle
+++ b/hello_sdl_android/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.sdl.hellosdlandroid"
         minSdkVersion 9
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -58,6 +58,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:25.4.0'
-    compile 'com.smartdevicelink:sdl_android:4.4.0'
+    compile 'com.smartdevicelink:sdl_android:RC2-4.5.0'
     testCompile 'junit:junit:4.12'
 }

--- a/hello_sdl_android/app/build.gradle
+++ b/hello_sdl_android/app/build.gradle
@@ -2,10 +2,9 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.sdl.hellosdlandroid"
-        minSdkVersion 9
+        minSdkVersion 14
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
@@ -17,6 +16,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    flavorDimensions "default"
     productFlavors{
         mbt_high {
             buildConfigField 'String', 'TRANSPORT', '"MBT"'
@@ -53,11 +53,11 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.4.0'
-    compile 'com.smartdevicelink:sdl_android:RC2-4.5.0'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.smartdevicelink:sdl_android:4.5.0'
+    testImplementation 'junit:junit:4.12'
 }

--- a/hello_sdl_android/app/src/main/AndroidManifest.xml
+++ b/hello_sdl_android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
             android:name=".LockScreenActivity"/>
 
         <activity android:name="com.smartdevicelink.transport.USBAccessoryAttachmentActivity"
-                  android:launchMode="singleTop">
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED" />
             </intent-filter>
@@ -47,8 +47,14 @@
         <service
             android:name=".SdlRouterService"
             android:exported="true"
-            android:process="com.smartdevicelink.router"
-            tools:ignore="ExportedService"/>
+            android:process="com.smartdevicelink.router">
+            <intent-filter>
+                <action android:name="com.smartdevicelink.router.service"/>
+            </intent-filter>
+            <meta-data android:name="@string/sdl_router_service_version_name"  android:value="@integer/sdl_router_service_version_value" />
+            <!-- Optional. Will default to false -->
+            <meta-data android:name="@string/sdl_router_service_is_custom_name" android:value="false" />
+        </service>
         <receiver
             android:name=".SdlReceiver"
             android:enabled="true"

--- a/hello_sdl_android/app/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/hello_sdl_android/app/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -2,6 +2,7 @@ package com.sdl.hellosdlandroid;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.util.Log;
 
 import com.smartdevicelink.transport.SdlBroadcastReceiver;
@@ -16,7 +17,15 @@ public class SdlReceiver  extends SdlBroadcastReceiver {
 	public void onSdlEnabled(Context context, Intent intent) {
 		Log.d(TAG, "SDL Enabled");
 		intent.setClass(context, SdlService.class);
-		context.startService(intent);
+
+		// SdlService needs to be foregrounded in Android O and above
+		// This will prevent apps in the background from crashing when they try to start SdlService
+		// Because Android O doesn't allow background apps to start background services
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			context.startForegroundService(intent);
+		} else {
+			context.startService(intent);
+		}
 	}
 
 	@Override

--- a/hello_sdl_android/app/src/main/java/com/sdl/hellosdlandroid/SdlService.java
+++ b/hello_sdl_android/app/src/main/java/com/sdl/hellosdlandroid/SdlService.java
@@ -1,11 +1,14 @@
 package com.sdl.hellosdlandroid;
 
+import android.annotation.SuppressLint;
+import android.app.Notification;
 import android.app.Service;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.hardware.usb.UsbAccessory;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
 
@@ -129,6 +132,8 @@ public class SdlService extends Service implements IProxyListenerALM{
 	private static final String TEST_COMMAND_NAME 		= "Test Command";
 	private static final int TEST_COMMAND_ID 			= 1;
 
+	private static final int FOREGROUND_SERVICE_ID = 849;
+
 	// TCP/IP transport config
 	// The default port is 12345
 	// The IP is of the machine that is running SDL Core
@@ -155,6 +160,22 @@ public class SdlService extends Service implements IProxyListenerALM{
         Log.d(TAG, "onCreate");
 		super.onCreate();
 		remoteFiles = new ArrayList<>();
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			enterForeground();
+		}
+	}
+
+	@SuppressLint("NewApi")
+	public void enterForeground() {
+		Notification notification = new Notification.Builder(this)
+				.setContentTitle("SmartDeviceLink")
+				.setContentText(getString(R.string.app_name))
+				.setSmallIcon(R.drawable.ic_sdl)
+				.setTicker("SmartDeviceLink")
+				.setPriority(Notification.PRIORITY_DEFAULT)
+				.build();
+		startForeground(FOREGROUND_SERVICE_ID, notification);
 	}
 
 	@Override

--- a/hello_sdl_android/build.gradle
+++ b/hello_sdl_android/build.gradle
@@ -7,9 +7,10 @@ buildscript {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/hello_sdl_android/gradle/wrapper/gradle-wrapper.properties
+++ b/hello_sdl_android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 10 12:00:41 EDT 2017
+#Thu Mar 29 13:47:09 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Fixes #29 & #31 

### Summary

- Update AndroidManifest.xml to include metadata additions
- Start the SdlService as foregrounded service in the SdlReceiver 
- Update the target version to 26
- Update SDL library to 4.5
- Update support library in gradle file 
- Update gradle plugin to the latest version
- Change "compile" to "implementation" for dependencies in the gradle file (recommended by Google)
- Add a default flavor dimension (required by the new gradle plugin)
- Change minSdkVersion to 14 (required by the new support library)
- Remove build tools declaration from grade file (It will use the newest one available by default)


### Testing

- Tested against TDK