### PR TITLE
update hello sdl android to lib v4.6

### DIFF
--- a/hello_sdl_android/app/build.gradle
+++ b/hello_sdl_android/app/build.gradle
@@ -58,6 +58,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.smartdevicelink:sdl_android:4.5.0'
+    implementation 'com.smartdevicelink:sdl_android:4.+'
     testImplementation 'junit:junit:4.12'
 }

--- a/hello_sdl_android/app/proguard-rules.pro
+++ b/hello_sdl_android/app/proguard-rules.pro
@@ -16,6 +16,9 @@
 #   public *;
 #}
 
+-keep class com.smartdevicelink.** { *; }
+-keep class com.livio.** { *; }
+
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
 #-keepattributes SourceFile,LineNumberTable

--- a/hello_sdl_android/app/src/main/AndroidManifest.xml
+++ b/hello_sdl_android/app/src/main/AndroidManifest.xml
@@ -60,10 +60,7 @@
             tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.smartdevicelink.USB_ACCESSORY_ATTACHED"/> <!--For AOA -->
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
-                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
-                <action android:name="android.bluetooth.adapter.action.STATE_CHANGED" />
                 <action android:name="sdl.router.startservice" />
             </intent-filter>
         </receiver>


### PR DESCRIPTION
Fixes #36 

This PR is **ready** for review.

### Testing Plan
Tested BT and USB functionality against a Ford TDK

### Summary
- Update library implementation line to use 4.6
- remove unneeded intent filters
- add proguard rules in case someone wants to test obfuscation

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)